### PR TITLE
Polish the home gallery layout

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,6 +32,7 @@ const gallery = [
 		label: 'Event',
 		title: '环舟山 2026',
 		position: 'center 63%',
+		fit: 'contain',
 	},
 	{
 		src: cornerTraining,
@@ -46,6 +47,7 @@ const gallery = [
 		label: 'Together',
 		title: '雨林骑行',
 		position: 'center 62%',
+		fit: 'contain',
 	},
 ];
 ---
@@ -107,14 +109,14 @@ const gallery = [
 								data-index={index}
 								data-caption={`${photo.label} / ${photo.title}`}
 								aria-hidden={index === 0 ? 'false' : 'true'}
-								style={`--photo-position: ${photo.position}`}
+								style={`--photo-position: ${photo.position}; --photo-url: url(${photo.src.src})`}
 							>
 								<Image
 									src={photo.src}
 									alt={photo.alt}
 									widths={[640, 960, 1280, 1600]}
-									sizes="(max-width: 720px) 82vw, 900px"
-									quality={82}
+									sizes="(max-width: 760px) 94vw, (max-width: 1120px) 72vw, 820px"
+									quality={84}
 									loading={index === 0 ? 'eager' : 'lazy'}
 									fetchpriority={index === 0 ? 'high' : 'auto'}
 								/>
@@ -142,8 +144,13 @@ const gallery = [
 								aria-current={index === 0 ? 'true' : 'false'}
 								style={`--photo-position: ${photo.position}`}
 							>
-								<Image src={photo.src} alt="" width={180} height={116} quality={72} loading="lazy" />
-								<span>{String(index + 1).padStart(2, '0')}</span>
+								<span class="gallery-thumb-image">
+									<Image src={photo.src} alt="" width={180} height={116} quality={72} loading="lazy" />
+								</span>
+								<span class="gallery-thumb-copy">
+									<small>{String(index + 1).padStart(2, '0')} / {photo.label}</small>
+									<strong>{photo.title}</strong>
+								</span>
 							</button>
 						))}
 					</div>
@@ -335,9 +342,15 @@ const gallery = [
 		--gallery-road-blue: #3aa5ff;
 		--gallery-marker-yellow: #f4c84b;
 		--gallery-brake-red: #ef5c71;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) clamp(10.5rem, 20vw, 13rem);
+		gap: clamp(0.7rem, 1.6vw, 1rem);
 		margin-top: 1.2rem;
-		padding: clamp(0.85rem, 2vw, 1.35rem);
+		padding: clamp(0.9rem, 2.2vw, 1.45rem);
 		overflow: hidden;
+		background:
+			radial-gradient(circle at 92% 8%, rgba(58, 165, 255, 0.1), transparent 30%),
+			rgba(var(--surface-1), 0.76);
 	}
 
 	.gallery-heading,
@@ -349,54 +362,63 @@ const gallery = [
 	}
 
 	.gallery-heading {
+		grid-column: 1 / -1;
 		justify-content: space-between;
 		gap: 1rem;
-		padding: 0.35rem 0.2rem clamp(0.9rem, 2vw, 1.2rem);
+		padding: 0.25rem 0.1rem clamp(0.95rem, 2vw, 1.25rem);
+		border-bottom: 1px solid rgba(var(--border), 0.22);
 	}
 
 	.gallery-heading h2 {
 		margin: 0;
-		font-size: clamp(2rem, 5vw, 3.8rem);
-		line-height: 0.95;
-		letter-spacing: -0.045em;
+		font-size: clamp(2.1rem, 5vw, 3.85rem);
+		line-height: 0.92;
+		letter-spacing: -0.05em;
 	}
 
 	.gallery-status {
-		gap: 1rem;
+		gap: clamp(0.7rem, 2vw, 1.15rem);
 	}
 
 	.gallery-count {
-		min-width: 4.9rem;
+		min-width: 5rem;
 		color: rgb(var(--gray));
-		font-size: 0.76rem;
+		font-size: 0.75rem;
 		font-variant-numeric: tabular-nums;
 		font-weight: 700;
-		letter-spacing: 0.13em;
+		letter-spacing: 0.14em;
+		text-align: right;
 	}
 
 	.gallery-controls {
-		gap: 0.35rem;
+		gap: 0;
+		overflow: hidden;
+		border: 1px solid rgba(var(--border), 0.34);
+		border-radius: 999px;
+		background: rgba(var(--surface-0), 0.54);
 	}
 
 	.gallery-controls button {
 		display: grid;
 		place-items: center;
-		width: 2.5rem;
-		height: 2.5rem;
+		width: 2.45rem;
+		height: 2.45rem;
 		padding: 0;
-		border: 1px solid rgba(var(--border), 0.35);
-		border-radius: 999px;
-		background: rgba(var(--surface-0), 0.64);
+		border: 0;
+		border-radius: 0;
+		background: transparent;
 		color: rgb(var(--gray-dark));
 		cursor: pointer;
-		transition: color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+		transition: color 0.18s ease, background-color 0.18s ease;
+	}
+
+	.gallery-controls button + button {
+		border-left: 1px solid rgba(var(--border), 0.28);
 	}
 
 	.gallery-controls button:hover {
-		border-color: var(--gallery-marker-yellow);
 		background: rgba(244, 200, 75, 0.12);
 		color: var(--gallery-marker-yellow);
-		transform: translateY(-1px);
 	}
 
 	.gallery-controls button:focus-visible,
@@ -407,8 +429,8 @@ const gallery = [
 	}
 
 	.gallery-controls svg {
-		width: 1.15rem;
-		height: 1.15rem;
+		width: 1.12rem;
+		height: 1.12rem;
 		fill: none;
 		stroke: currentColor;
 		stroke-width: 1.8;
@@ -417,15 +439,19 @@ const gallery = [
 	}
 
 	[data-gallery-toggle-icon] {
-		font-size: 0.74rem;
+		font-size: 0.7rem;
 		font-weight: 700;
 		line-height: 1;
 	}
 
 	.gallery-viewport {
+		grid-column: 1;
+		min-width: 0;
 		overflow: hidden;
-		border-radius: calc(var(--radius-lg) - 5px);
+		border: 1px solid rgba(255, 255, 255, 0.07);
+		border-radius: calc(var(--radius-lg) - 6px);
 		background: #07101a;
+		box-shadow: 0 18px 40px rgba(3, 8, 13, 0.18);
 		touch-action: pan-y;
 		cursor: grab;
 	}
@@ -436,20 +462,20 @@ const gallery = [
 
 	.gallery-track {
 		display: flex;
-		gap: clamp(0.55rem, 1.2vw, 0.9rem);
-		width: max-content;
-		transition: transform 0.78s cubic-bezier(0.22, 1, 0.36, 1);
+		gap: 0.8rem;
+		width: 100%;
+		transition: transform 0.72s cubic-bezier(0.22, 1, 0.36, 1);
 		will-change: transform;
 	}
 
 	.gallery-slide {
 		position: relative;
-		flex: 0 0 calc((min(1080px, 100vw - 2.5rem) - clamp(1.7rem, 4vw, 2.7rem)) - clamp(4.2rem, 10vw, 7rem));
-		width: calc((min(1080px, 100vw - 2.5rem) - clamp(1.7rem, 4vw, 2.7rem)) - clamp(4.2rem, 10vw, 7rem));
+		flex: 0 0 100%;
+		width: 100%;
 		aspect-ratio: 16 / 10;
 		margin: 0;
 		overflow: hidden;
-		border-radius: calc(var(--radius-lg) - 5px);
+		border-radius: calc(var(--radius-lg) - 7px);
 		background: #07101a;
 		isolation: isolate;
 	}
@@ -457,78 +483,97 @@ const gallery = [
 	.gallery-slide::after {
 		content: '';
 		position: absolute;
-		inset: 42% 0 0;
-		z-index: 1;
-		background: linear-gradient(transparent, rgba(3, 8, 13, 0.72));
+		inset: 36% 0 0;
+		z-index: 2;
+		background: linear-gradient(transparent, rgba(3, 8, 13, 0.2) 25%, rgba(3, 8, 13, 0.82));
 		pointer-events: none;
 	}
 
+	.gallery-slide--contain::before {
+		content: '';
+		position: absolute;
+		inset: -2rem;
+		z-index: 0;
+		background-image: var(--photo-url);
+		background-position: var(--photo-position);
+		background-size: cover;
+		filter: blur(28px) saturate(0.8) brightness(0.45);
+		transform: scale(1.08);
+		opacity: 0.82;
+	}
+
 	.gallery-slide :global(img) {
+		position: relative;
+		z-index: 1;
 		display: block;
 		width: 100%;
 		height: 100%;
 		border-radius: 0;
 		object-fit: cover;
 		object-position: var(--photo-position);
-		transform: scale(1.01);
-		transition: transform 6.5s ease-out;
+		transform: scale(1.005);
+		transition: transform 6.5s ease-out, filter 0.45s ease;
 	}
 
 	.gallery-slide[aria-hidden='false'] :global(img) {
-		transform: scale(1.055);
+		transform: scale(1.035);
 	}
 
-	.gallery-slide--contain :global(img) {
-		object-fit: contain;
-		transform: none;
-	}
-
+	.gallery-slide--contain :global(img),
 	.gallery-slide--contain[aria-hidden='false'] :global(img) {
+		object-fit: contain;
 		transform: none;
 	}
 
 	.gallery-slide figcaption {
 		position: absolute;
-		left: clamp(1rem, 3vw, 2rem);
-		bottom: clamp(0.85rem, 2vw, 1.5rem);
-		z-index: 2;
-		display: flex;
-		align-items: baseline;
-		gap: 0.75rem;
+		left: clamp(1.15rem, 3vw, 2.15rem);
+		bottom: clamp(1rem, 2.5vw, 1.75rem);
+		z-index: 3;
+		display: grid;
+		gap: 0.32rem;
 		color: #fff;
-		text-shadow: 0 2px 20px rgba(0, 0, 0, 0.68);
+		text-shadow: 0 2px 24px rgba(0, 0, 0, 0.72);
 	}
 
 	.gallery-slide figcaption span {
-		padding: 0.22rem 0.45rem;
-		border-radius: 2px;
-		background: var(--gallery-marker-yellow);
-		color: #17130b;
-		font-size: 0.63rem;
-		font-weight: 700;
-		letter-spacing: 0.13em;
+		display: flex;
+		align-items: center;
+		gap: 0.45rem;
+		font-size: 0.64rem;
+		font-weight: 750;
+		letter-spacing: 0.16em;
 		line-height: 1.1;
 		text-transform: uppercase;
-		text-shadow: none;
+	}
+
+	.gallery-slide figcaption span::before {
+		content: '';
+		width: 1.35rem;
+		height: 2px;
+		background: var(--gallery-marker-yellow);
+		box-shadow: 1.5rem 0 0 var(--gallery-brake-red);
 	}
 
 	.gallery-slide figcaption strong {
-		font-size: clamp(1.05rem, 2.6vw, 1.65rem);
-		letter-spacing: -0.02em;
+		font-size: clamp(1.55rem, 4vw, 2.65rem);
+		letter-spacing: -0.045em;
+		line-height: 1;
 	}
 
 	.gallery-footer {
-		gap: 1rem;
+		grid-column: 2;
 		align-items: stretch;
-		padding: 0.9rem 0.15rem 0.1rem;
+		flex-direction: column;
+		gap: 0.75rem;
+		min-width: 0;
 	}
 
 	.gallery-progress {
 		position: relative;
-		flex: 1;
-		min-width: 5rem;
+		flex: none;
+		width: 100%;
 		height: 2px;
-		margin: auto 0;
 		overflow: hidden;
 		background: rgba(var(--border), 0.34);
 	}
@@ -538,61 +583,114 @@ const gallery = [
 		width: var(--gallery-progress, 20%);
 		height: 100%;
 		background: linear-gradient(90deg, var(--gallery-road-blue), var(--gallery-marker-yellow) 72%, var(--gallery-brake-red));
-		transition: width 0.55s cubic-bezier(0.22, 1, 0.36, 1);
+		transition: width 0.5s cubic-bezier(0.22, 1, 0.36, 1);
 	}
 
 	.gallery-thumbs {
 		display: grid;
-		grid-template-columns: repeat(5, minmax(3.6rem, 5.8rem));
-		gap: 0.4rem;
+		grid-template-rows: repeat(5, minmax(0, 1fr));
+		gap: 0.45rem;
+		flex: 1;
+		min-height: 0;
 	}
 
 	.gallery-thumb {
 		position: relative;
-		aspect-ratio: 1.55;
-		padding: 0;
+		display: grid;
+		grid-template-columns: minmax(3.4rem, 4.35rem) minmax(0, 1fr);
+		gap: 0.62rem;
+		align-items: center;
+		min-height: 0;
+		padding: 0.34rem;
 		overflow: hidden;
-		border: 1px solid rgba(var(--border), 0.3);
-		border-radius: 4px;
-		background: #07101a;
+		border: 1px solid transparent;
+		border-radius: 6px;
+		background: rgba(var(--surface-0), 0.36);
+		color: rgb(var(--gray-dark));
+		text-align: left;
 		cursor: pointer;
-		opacity: 0.52;
-		transition: opacity 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+		opacity: 0.58;
+		transition: opacity 0.18s ease, border-color 0.18s ease, background-color 0.18s ease, transform 0.18s ease;
+	}
+
+	.gallery-thumb::before {
+		content: '';
+		position: absolute;
+		inset: 0 auto 0 0;
+		width: 2px;
+		background: transparent;
+		transition: background-color 0.18s ease;
 	}
 
 	.gallery-thumb:hover {
-		opacity: 0.82;
-		transform: translateY(-2px);
+		background: rgba(var(--surface-0), 0.62);
+		opacity: 0.88;
+		transform: translateX(-2px);
 	}
 
 	.gallery-thumb[aria-current='true'] {
-		border-color: var(--gallery-marker-yellow);
+		border-color: rgba(244, 200, 75, 0.3);
+		background: rgba(244, 200, 75, 0.08);
 		opacity: 1;
 	}
 
-	.gallery-thumb :global(img) {
+	.gallery-thumb[aria-current='true']::before {
+		background: var(--gallery-marker-yellow);
+	}
+
+	.gallery-thumb-image {
+		display: block;
+		aspect-ratio: 1.3;
+		overflow: hidden;
+		border-radius: 3px;
+		background: #07101a;
+	}
+
+	.gallery-thumb-image :global(img) {
 		display: block;
 		width: 100%;
 		height: 100%;
 		border-radius: 0;
 		object-fit: cover;
 		object-position: var(--photo-position);
+		filter: saturate(0.82);
+		transition: filter 0.18s ease, transform 0.35s ease;
 	}
 
-	.gallery-thumb span {
-		position: absolute;
-		right: 0.25rem;
-		bottom: 0.15rem;
-		padding: 0.05rem 0.18rem;
-		background: rgba(3, 8, 13, 0.68);
-		color: #fff;
-		font-size: 0.55rem;
+	.gallery-thumb:hover .gallery-thumb-image :global(img),
+	.gallery-thumb[aria-current='true'] .gallery-thumb-image :global(img) {
+		filter: saturate(1);
+		transform: scale(1.045);
+	}
+
+	.gallery-thumb-copy {
+		display: grid;
+		gap: 0.2rem;
+		min-width: 0;
+	}
+
+	.gallery-thumb-copy small {
+		overflow: hidden;
+		color: rgb(var(--gray));
+		font-size: 0.54rem;
 		font-variant-numeric: tabular-nums;
 		font-weight: 700;
-		letter-spacing: 0.08em;
+		letter-spacing: 0.09em;
+		text-overflow: ellipsis;
+		text-transform: uppercase;
+		white-space: nowrap;
 	}
 
-	@media (max-width: 720px) {
+	.gallery-thumb-copy strong {
+		overflow: hidden;
+		font-size: 0.78rem;
+		font-weight: 700;
+		line-height: 1.2;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	@media (max-width: 760px) {
 		.hero {
 			grid-template-columns: 1fr;
 			gap: 1.5rem;
@@ -603,45 +701,82 @@ const gallery = [
 			font-size: clamp(3.1rem, 18vw, 5rem);
 		}
 
+		.ride-gallery {
+			display: block;
+			padding: 0.78rem;
+		}
+
 		.gallery-heading {
 			align-items: flex-end;
+			padding: 0.25rem 0.1rem 0.85rem;
+		}
+
+		.gallery-heading h2 {
+			font-size: clamp(2rem, 11vw, 3rem);
 		}
 
 		.gallery-status {
 			flex-direction: column;
 			align-items: flex-end;
-			gap: 0.45rem;
+			gap: 0.42rem;
+		}
+
+		.gallery-count {
+			font-size: 0.65rem;
 		}
 
 		.gallery-controls button {
-			width: 2.2rem;
-			height: 2.2rem;
+			width: 2.12rem;
+			height: 2.12rem;
+		}
+
+		.gallery-viewport {
+			margin-top: 0.75rem;
 		}
 
 		.gallery-slide {
-			flex-basis: calc(100vw - 1.5rem - 1.7rem - 3.4rem);
-			width: calc(100vw - 1.5rem - 1.7rem - 3.4rem);
-			aspect-ratio: 4 / 5;
+			aspect-ratio: 4 / 3;
 		}
 
-		.gallery-slide figcaption {
-			align-items: flex-start;
-			flex-direction: column;
-			gap: 0.4rem;
+		.gallery-slide figcaption strong {
+			font-size: clamp(1.45rem, 8vw, 2.1rem);
 		}
 
 		.gallery-footer {
-			flex-direction: column;
-			gap: 0.75rem;
-		}
-
-		.gallery-progress {
-			flex: none;
-			width: 100%;
+			gap: 0.65rem;
+			padding-top: 0.7rem;
 		}
 
 		.gallery-thumbs {
-			grid-template-columns: repeat(5, 1fr);
+			display: grid;
+			grid-template-columns: repeat(5, minmax(0, 1fr));
+			grid-template-rows: none;
+			gap: 0.32rem;
+		}
+
+		.gallery-thumb {
+			display: block;
+			padding: 0;
+			border-radius: 4px;
+		}
+
+		.gallery-thumb::before {
+			inset: auto 0 0;
+			width: auto;
+			height: 2px;
+		}
+
+		.gallery-thumb:hover {
+			transform: translateY(-2px);
+		}
+
+		.gallery-thumb-image {
+			aspect-ratio: 1.2;
+			border-radius: 3px;
+		}
+
+		.gallery-thumb-copy {
+			display: none;
 		}
 	}
 
@@ -650,6 +785,7 @@ const gallery = [
 		.gallery-progress span,
 		.gallery-slide :global(img),
 		.gallery-thumb,
+		.gallery-thumb-image :global(img),
 		.gallery-controls button {
 			transition: none;
 		}


### PR DESCRIPTION
## Summary

- reshape the home gallery into a desktop editorial layout with a primary stage and a compact side rail
- remove the duplicated “peek + thumbnails” visual hierarchy while keeping keyboard, swipe, autoplay, and reduced-motion behavior
- add labeled thumbnail navigation with clearer active states
- render portrait assets with a blurred backdrop instead of aggressively cropping them
- simplify the control group and refine captions, spacing, shadows, and responsive behavior
- switch mobile to a calmer 4:3 stage with compact thumbnail tabs

## Notes

The interaction logic is intentionally preserved. This PR is primarily a markup/CSS pass, with image sizing adjusted for the new layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes on the home page gallery; no auth, data, or interaction logic changes beyond layout and styling.
> 
> **Overview**
> **Reshapes the home ride gallery** from a peeking horizontal strip into a **desktop two-column layout**: full-width main stage plus a vertical side rail for progress and thumbnails.
> 
> Slides are now **100% width** (no adjacent peek). **`fit: 'contain'`** is set on more photos, with a **blurred `--photo-url` backdrop** on contain slides so portrait assets aren’t hard-cropped. Main **`Image`** `sizes`/`quality` are tuned for the new layout.
> 
> **Thumbnails** gain labeled copy (index, label, title) and clearer active/hover styling on desktop; **mobile** (breakpoint **760px**) stacks the gallery, uses a **4:3** stage, horizontal compact thumb tabs, and hides thumb text.
> 
> **Controls, captions, and chrome** are refined (segmented pill controls, larger captions, heading border, gallery background). Carousel **behavior is unchanged**—markup/CSS and image attributes only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30d4c3ec1044e7a480c500875be521a1dc3c8f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->